### PR TITLE
Travis switch to Open JDK and Ubuntu Xenial (#504)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 
 language: java
 sudo: required
+dist: xenial
 
 branches:
   except:
@@ -19,17 +20,18 @@ branches:
 
 addons:
   apt:
-    sources:
-      - mysql-5.7-trusty
     packages:
       - libmysql-java
       - mysql-server
       - mysql-client
 
+services:
+  - mysql
+
 env:
   global:
     - ANT_HOME=$HOME/apache-ant-1.10.5
-    - M2_HOME=/usr/local/maven-3.5.2
+    - M2_HOME=/usr/local/maven-3.6.0
   matrix:
     - TEST_TARGET=test-core
     - TEST_TARGET=test-jpa22
@@ -40,8 +42,8 @@ env:
     - TEST_TARGET=build-distribution
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:

--- a/dbws/eclipselink.dbws.test.oracle/antbuild.xml
+++ b/dbws/eclipselink.dbws.test.oracle/antbuild.xml
@@ -107,6 +107,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/dbws/eclipselink.dbws.test/antbuild.xml
+++ b/dbws/eclipselink.dbws.test/antbuild.xml
@@ -98,6 +98,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -114,6 +114,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.extension.corba.test/antbuild.xml
+++ b/foundation/eclipselink.extension.corba.test/antbuild.xml
@@ -101,6 +101,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.extension.oracle.spatial.test/antbuild.xml
+++ b/foundation/eclipselink.extension.oracle.spatial.test/antbuild.xml
@@ -107,6 +107,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.extension.oracle.test/antbuild.xml
+++ b/foundation/eclipselink.extension.oracle.test/antbuild.xml
@@ -107,6 +107,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -108,6 +108,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -112,6 +112,10 @@
     <!-- JVM used to run tests -->
     <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
     <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+    <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+    <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+        <not><available file="${test.junit.jvm}/release"/></not>
+    </condition>
     <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
     <!-- JVM specific settings -->


### PR DESCRIPTION
[Non Bug] Travis JDK switch
Due license troubles JDK switch from OracleJDK to OpenJDK.
There is some fix in antbuild.xml files for Open JDK 8. Open JDK 8 installation in Travis (Ubuntu-Xenial) doesn't contains $JAVA_HOME/release file used by Ant build files to detect Java/JDK version.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>